### PR TITLE
fix: add missing complex_num print to class 1 Python notebook

### DIFF
--- a/clase1/content/jupyter_notebooks/2 - Usando Python.ipynb
+++ b/clase1/content/jupyter_notebooks/2 - Usando Python.ipynb
@@ -24,6 +24,7 @@
      "text": [
       "La variable entero es igual a 3 y es de tipo <class 'int'>\n",
       "La variable var_float es igual a 3.1 y es de tipo <class 'float'>\n",
+      "La variable complex_num es igual a (3+1j) y es de tipo <class 'complex'>\n",
       "La variable string es igual a Hola, soy un string y es de tipo <class 'str'>\n",
       "La variable booleano es igual a True y es de tipo <class 'bool'>\n",
       "La variable lista es igual a [0, 1, 3] y es de tipo <class 'list'>\n",
@@ -46,6 +47,7 @@
     "\n",
     "print(f\"La variable entero es igual a {entero} y es de tipo {type(entero)}\" )\n",
     "print(f\"La variable var_float es igual a {var_float} y es de tipo {type(var_float)}\" )\n",
+    "print(f\"La variable complex_num es igual a {complex_num} y es de tipo {type(complex_num)}\" )\n",
     "print(f\"La variable string es igual a {string} y es de tipo {type(string)}\" )\n",
     "print(f\"La variable booleano es igual a {booleano} y es de tipo {type(booleano)}\" )\n",
     "print(f\"La variable lista es igual a {lista} y es de tipo {type(lista)}\" )\n",


### PR DESCRIPTION
Se agrega un simple print que falta en la notebook de ejemplo de la Clase 1: "2 - Usando Python", para mostrar el resultado de la variable correspondiente al número complejo.